### PR TITLE
[nrf noup] fix: actions: Use ubuntu-latest agent

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -11,7 +11,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
   clang-build:
-    runs-on: zephyr_runner
+    runs-on: ubuntu-latest
     needs: clang-build-prep
     container:
       image: zephyrprojectrtos/ci:v0.21.0

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -15,7 +15,7 @@ jobs:
           access_token: ${{ github.token }}
 
   codecov:
-    runs-on: zephyr_runner
+    runs-on: ubuntu-latest
     needs: codecov-prep
     container:
       image: zephyrprojectrtos/ci:v0.21.0

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -22,7 +22,7 @@ jobs:
 
   twister-build-prep:
 
-    runs-on: zephyr_runner
+    runs-on: ubuntu-latest
     needs: twister-build-cleanup
     container:
       image: zephyrprojectrtos/ci:v0.21.0
@@ -105,7 +105,7 @@ jobs:
           echo "::set-output name=size::${size}";
 
   twister-build:
-    runs-on: zephyr_runner
+    runs-on: ubuntu-latest
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:


### PR DESCRIPTION
Upstream uses AWS self-hosted agent to run GitHub actions.
This commit sets actons to run on ubuntu-latest (generic GH agent).

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>