### PR TITLE
workflow: clang: Add missing matrix.platform

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        platform: ["native_posix"]
         subset: [1, 2, 3, 4, 5]
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.2


### PR DESCRIPTION
To align with the upstream.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>